### PR TITLE
Fix detection of Claude Code session limit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ The project follows a single-file architecture:
 ### Core Logic Flow
 1. Parses command line arguments for custom prompt and session type (new vs continue)
 2. Runs `claude -p 'check'` command
-3. Parses output for usage limit messages with format: `Claude AI usage limit reached|<timestamp>`
+3. Parses output for usage limit messages such as `Claude AI usage limit reached|<timestamp>`, `5-hour limit reached ∙ resets 3am`, `You've hit your limit · resets 4:20am (Europe/Warsaw)`, and `You've hit your session limit · resets 4:20am (Europe/Warsaw)`
 4. Calculates wait time from timestamp
 5. Displays countdown timer and waits
 6. Automatically runs either:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ chmod +x claude-auto-resume.sh
 ## How It Works
 
 1. **Detect Limits**: Execute `claude -p 'check'` command
-2. **Parse Output**: Look for `Claude AI usage limit reached|<timestamp>` format messages
+2. **Parse Output**: Look for supported usage-limit messages, including:
+   - `Claude AI usage limit reached|<timestamp>`
+   - `5-hour limit reached ∙ resets 3am`
+   - `You've hit your limit · resets 4:20am (Europe/Warsaw)`
+   - `You've hit your session limit · resets 4:20am (Europe/Warsaw)`
 3. **Calculate Wait Time**: Calculate required wait time based on timestamp
 4. **Display Countdown**: Show real-time remaining wait time
 5. **Auto Resume**: Automatically execute either:

--- a/README_zh.md
+++ b/README_zh.md
@@ -161,7 +161,11 @@ chmod +x claude-auto-resume.sh
 ## 工作原理
 
 1. **检测限制**：执行 `claude -p 'check'` 命令
-2. **解析输出**：查找 `Claude AI usage limit reached|<timestamp>` 格式的消息
+2. **解析输出**：查找支持的使用限制消息，包括：
+   - `Claude AI usage limit reached|<timestamp>`
+   - `5-hour limit reached ∙ resets 3am`
+   - `You've hit your limit · resets 4:20am (Europe/Warsaw)`
+   - `You've hit your session limit · resets 4:20am (Europe/Warsaw)`
 3. **计算等待时间**：根据时间戳计算所需等待时间
 4. **显示倒计时**：实时显示剩余等待时间
 5. **自动恢复**：自动执行以下命令之一：

--- a/claude-auto-resume.ps1
+++ b/claude-auto-resume.ps1
@@ -197,17 +197,21 @@ function Extract-OldFormatTimestamp {
 function Extract-NewFormatTimestamp {
   param([string]$ClaudeOutput)
 
-  $m = [regex]::Match($ClaudeOutput, 'resets\s+(\d+)(am|pm)', 'IgnoreCase')
+  $m = [regex]::Match($ClaudeOutput, 'resets\s+(\d{1,2})(?::(\d{2}))?(am|pm)', 'IgnoreCase')
   if (-not $m.Success) {
     Write-Host "[ERROR] Failed to extract reset time from new Claude output format."
-    Write-Host "[HINT] Expected format: 'X-hour limit reached - resets Xam/pm' or 'You've hit your limit  resets Xam/pm (Zone)'"
+    Write-Host "[HINT] Expected format: 'X-hour limit reached - resets Xam/pm' or 'You've hit your (session )?limit · resets X:XXam/pm (Zone)'"
     Write-Host "[SUGGESTION] Check if Claude CLI output format has changed."
     Write-Host "[DEBUG] Raw output: $ClaudeOutput"
     exit 2
   }
 
   $hour = [int]$m.Groups[1].Value
-  $period = $m.Groups[2].Value.ToLowerInvariant()
+  $minute = 0
+  if ($m.Groups[2].Success) {
+    $minute = [int]$m.Groups[2].Value
+  }
+  $period = $m.Groups[3].Value.ToLowerInvariant()
 
   if ($period -eq 'am') {
     if ($hour -eq 12) { $hour = 0 }
@@ -216,7 +220,7 @@ function Extract-NewFormatTimestamp {
   }
 
   $now = Get-Date
-  $todayReset = $now.Date.AddHours($hour)
+  $todayReset = $now.Date.AddHours($hour).AddMinutes($minute)
   if ($now -gt $todayReset) {
     $resume = $todayReset.AddDays(1)
   } else {
@@ -398,9 +402,8 @@ try {
   }
 
   $LIMIT_MSG = ''
-  $limitPattern = '(?i)(usage limit|limit reached|hit your limit).*resets'
-  $resetPattern = '(?i)resets\s+\d+(am|pm)'
-  if ($CLAUDE_OUTPUT -match $limitPattern -or $CLAUDE_OUTPUT -match $resetPattern) {
+  $limitPattern = '(?i)(Claude AI usage limit reached\||limit reached.*resets|hit your (session )?limit.*resets)'
+  if ($CLAUDE_OUTPUT -match $limitPattern) {
     $LIMIT_MSG = $CLAUDE_OUTPUT
   }
 
@@ -512,4 +515,3 @@ try {
 finally {
   Cleanup-Resources
 }
-

--- a/claude-auto-resume.sh
+++ b/claude-auto-resume.sh
@@ -57,7 +57,7 @@ cleanup_resources() {
     fi
     
     # Kill any background processes if they exist
-    if [ -n "$CLAUDE_PID" ]; then
+    if [ -n "${CLAUDE_PID:-}" ]; then
         echo "[INFO] Terminating Claude CLI process (PID: $CLAUDE_PID)..."
         kill $CLAUDE_PID 2>/dev/null
         # Wait a bit for graceful termination
@@ -88,8 +88,10 @@ cleanup_resources() {
 }
 
 # Set up signal handlers for graceful cleanup
-trap cleanup_on_exit EXIT
-trap interrupt_handler INT TERM
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    trap cleanup_on_exit EXIT
+    trap interrupt_handler INT TERM
+fi
 
 # Cross-platform timeout wrapper (GNU timeout not available on macOS)
 portable_timeout() {
@@ -179,9 +181,11 @@ parse_limit_message() {
         return
     fi
 
-    # Check for new format: X-hour limit reached ∙ resets Xam/pm or X:XXam/pm
-    # Also handles: You've hit your limit · resets 2am (Europe/Paris)
-    if echo "$claude_output" | grep -q -E "(limit reached|hit your limit).*resets"; then
+    # Check for new formats:
+    # - X-hour limit reached ∙ resets Xam/pm or X:XXam/pm
+    # - You've hit your limit · resets 2am (Europe/Paris)
+    # - You've hit your session limit · resets 4:20am (Europe/Warsaw)
+    if echo "$claude_output" | grep -q -E "(limit reached|hit your (session )?limit).*resets"; then
         local reset_time reset_hour reset_minute reset_period reset_hour_24
         local now_timestamp today_reset output_tz=""
 
@@ -189,7 +193,7 @@ parse_limit_message() {
         reset_time=$(echo "$claude_output" | grep -o "resets [0-9]*:*[0-9]*[ap]m" | awk '{print $2}')
         if [ -z "$reset_time" ]; then
             echo "[ERROR] Failed to extract reset time from new Claude output format."
-            echo "[HINT] Expected format: 'X-hour limit reached ∙ resets Xam/pm' or 'You've hit your limit · resets X:XXam/pm (TZ)'"
+            echo "[HINT] Expected format: 'X-hour limit reached ∙ resets Xam/pm' or 'You've hit your (session )?limit · resets X:XXam/pm (TZ)'"
             echo "[SUGGESTION] Check if Claude CLI output format has changed."
             echo "[DEBUG] Raw output: $claude_output"
             exit 2
@@ -280,9 +284,16 @@ parse_limit_message() {
     echo "  - 'Claude AI usage limit reached|<timestamp>'"
     echo "  - 'X-hour limit reached ∙ resets Xam/pm' or 'X:XXam/pm'"
     echo "  - 'You've hit your limit · resets Xam/pm (Timezone)'"
+    echo "  - 'You've hit your session limit · resets Xam/pm (Timezone)'"
     echo "[SUGGESTION] Check if Claude CLI output format has changed."
     echo "[DEBUG] Raw output: $claude_output"
     exit 2
+}
+
+detect_limit_message() {
+    local claude_output="$1"
+
+    echo "$claude_output" | grep -E "(Claude AI usage limit reached|limit reached.*resets|hit your (session )?limit.*resets)"
 }
 
 # Function to check network connectivity
@@ -366,6 +377,10 @@ EXAMPLES:
 
 EOF
 }
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
 
 # Parse command line arguments
 CUSTOM_PROMPT="$DEFAULT_PROMPT"
@@ -577,8 +592,9 @@ fi
 # 2. Check if usage limit is reached (support both old and new formats)
 # Old format: Claude AI usage limit reached|<timestamp>
 # New format: 5-hour limit reached ∙ resets 3am
-# Newest format: You've hit your limit · resets 2am (Europe/Paris)
-LIMIT_MSG=$(echo "$CLAUDE_OUTPUT" | grep -E "(Claude AI usage limit reached|limit reached.*resets|hit your limit.*resets)")
+# Newest formats: You've hit your limit · resets 2am (Europe/Paris)
+#                 You've hit your session limit · resets 4:20am (Europe/Warsaw)
+LIMIT_MSG=$(detect_limit_message "$CLAUDE_OUTPUT")
 
 # Test mode: simulate usage limit
 if [ "$TEST_MODE" = true ]; then

--- a/test_message_formats.sh
+++ b/test_message_formats.sh
@@ -37,7 +37,7 @@ run_test() {
     fi
 }
 
-# Test extract_old_format_timestamp function
+# Test parse_limit_message with old timestamp format
 test_old_format() {
     echo -e "${YELLOW}Testing old format timestamp extraction...${NC}"
     
@@ -47,12 +47,12 @@ test_old_format() {
     # Test cases for old format
     test_output="Claude AI usage limit reached|1735776000"
     expected_timestamp="1735776000"
-    actual_timestamp=$(extract_old_format_timestamp "$test_output")
+    actual_timestamp=$(parse_limit_message "$test_output")
     run_test "old format extraction" "$expected_timestamp" "$actual_timestamp"
     
     # Test error case
     test_output="Claude AI usage limit reached|invalid"
-    if extract_old_format_timestamp "$test_output" 2>/dev/null; then
+    if ( parse_limit_message "$test_output" >/dev/null 2>&1 ); then
         echo -e "${RED}FAIL${NC}: Should have failed with invalid timestamp"
     else
         echo -e "${GREEN}PASS${NC}: Correctly failed with invalid timestamp"
@@ -61,7 +61,7 @@ test_old_format() {
     TESTS_RUN=$((TESTS_RUN + 1))
 }
 
-# Test extract_new_format_timestamp function
+# Test parse_limit_message with reset-time formats
 test_new_format() {
     echo -e "${YELLOW}Testing new format timestamp extraction...${NC}"
     
@@ -76,11 +76,14 @@ test_new_format() {
         "5-hour limit reached ∙ resets 11:45pm"
         "5-hour limit reached ∙ resets 12pm"
         "5-hour limit reached ∙ resets 6:15am"
+        "You've hit your limit · resets 4:20am (Europe/Warsaw)"
+        "You've hit your session limit · resets 4:20am (Europe/Warsaw)"
+        "You've hit your session limit · resets 2am (Europe/Paris)"
     )
     
     for test_case in "${test_cases[@]}"; do
         echo "  Testing: $test_case"
-        if timestamp=$(extract_new_format_timestamp "$test_case" 2>/dev/null); then
+        if timestamp=$(parse_limit_message "$test_case" 2>/dev/null); then
             # Verify timestamp is reasonable (within next 24 hours)
             if [ "$timestamp" -gt "$current_time" ] && [ "$timestamp" -lt $((current_time + 86400)) ]; then
                 echo -e "    ${GREEN}PASS${NC}: Generated valid future timestamp"
@@ -96,7 +99,7 @@ test_new_format() {
     
     # Test error case
     test_output="5-hour limit reached ∙ resets invalid"
-    if extract_new_format_timestamp "$test_output" 2>/dev/null; then
+    if ( parse_limit_message "$test_output" >/dev/null 2>&1 ); then
         echo -e "${RED}FAIL${NC}: Should have failed with invalid time format"
     else
         echo -e "${GREEN}PASS${NC}: Correctly failed with invalid time format"
@@ -118,10 +121,13 @@ test_message_detection() {
         "5-hour limit reached ∙ resets 3am"
         "5-hour limit reached ∙ resets 12:30am"
         "Some text 5-hour limit reached ∙ resets 11:45pm more text"
+        "You've hit your limit · resets 4:20am (Europe/Warsaw)"
+        "You've hit your session limit · resets 4:20am (Europe/Warsaw)"
+        "You've hit your session limit · resets 2am (Europe/Paris)"
     )
     
     for msg in "${old_messages[@]}"; do
-        if echo "$msg" | grep -qE "(Claude AI usage limit reached|limit reached.*resets)"; then
+        if detect_limit_message "$msg" >/dev/null; then
             echo -e "  ${GREEN}PASS${NC}: Detected old format message"
             TESTS_PASSED=$((TESTS_PASSED + 1))
         else
@@ -131,7 +137,7 @@ test_message_detection() {
     done
     
     for msg in "${new_messages[@]}"; do
-        if echo "$msg" | grep -qE "(Claude AI usage limit reached|limit reached.*resets)"; then
+        if detect_limit_message "$msg" >/dev/null; then
             echo -e "  ${GREEN}PASS${NC}: Detected new format message"
             TESTS_PASSED=$((TESTS_PASSED + 1))
         else
@@ -139,6 +145,50 @@ test_message_detection() {
         fi
         TESTS_RUN=$((TESTS_RUN + 1))
     done
+
+    local unrelated_messages=(
+        "Error: authentication failed"
+        "You've hit your context limit. Try a shorter prompt."
+    )
+
+    for msg in "${unrelated_messages[@]}"; do
+        if detect_limit_message "$msg" >/dev/null; then
+            echo -e "  ${RED}FAIL${NC}: Incorrectly detected unrelated message: $msg"
+        else
+            echo -e "  ${GREEN}PASS${NC}: Ignored unrelated message"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        fi
+        TESTS_RUN=$((TESTS_RUN + 1))
+    done
+}
+
+run_script_with_mock_claude() {
+    local mock_dir
+    mock_dir=$(mktemp -d)
+
+    cat > "${mock_dir}/claude" <<'EOF'
+#!/bin/bash
+
+if [[ "$*" == *"--help"* ]]; then
+    echo "Usage: claude [options]"
+    echo "  --dangerously-skip-permissions"
+    exit 0
+fi
+
+if [[ "$*" == *"check"* ]]; then
+    echo "No usage limit detected"
+    exit 0
+fi
+
+echo "Mock Claude resume completed"
+exit 0
+EOF
+
+    chmod +x "${mock_dir}/claude"
+    PATH="${mock_dir}:$PATH" timeout 15s "$SCRIPT_PATH" "$@" >/dev/null 2>&1
+    local status=$?
+    rm -rf "$mock_dir"
+    return $status
 }
 
 # Test script integration
@@ -147,7 +197,7 @@ test_script_integration() {
     
     # Test old format in test mode
     echo "  Testing old format test mode..."
-    if timeout 15s "$SCRIPT_PATH" --test-mode 2 "test" >/dev/null 2>&1; then
+    if run_script_with_mock_claude --test-mode 2 "test"; then
         echo -e "  ${GREEN}PASS${NC}: Old format test mode completed"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
@@ -157,7 +207,7 @@ test_script_integration() {
     
     # Test new format in test mode
     echo "  Testing new format test mode..."
-    if timeout 15s "$SCRIPT_PATH" --test-mode 2 --test-new-format "test" >/dev/null 2>&1; then
+    if run_script_with_mock_claude --test-mode 2 --test-new-format "test"; then
         echo -e "  ${GREEN}PASS${NC}: New format test mode completed"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else

--- a/test_message_parsing.sh
+++ b/test_message_parsing.sh
@@ -18,8 +18,11 @@ parse_limit_message() {
         return
     fi
     
-    # Check for new format: X-hour limit reached ∙ resets Xam/pm or X:XXam/pm
-    if echo "$claude_output" | grep -q "limit reached.*resets"; then
+    # Check for new formats:
+    # - X-hour limit reached ∙ resets Xam/pm or X:XXam/pm
+    # - You've hit your limit · resets Xam/pm (Timezone)
+    # - You've hit your session limit · resets Xam/pm (Timezone)
+    if echo "$claude_output" | grep -q -E "(limit reached|hit your (session )?limit).*resets"; then
         local reset_time reset_hour reset_minute reset_period reset_hour_24
         local now_timestamp today_reset
         
@@ -105,6 +108,9 @@ test_cases=(
     "5-hour limit reached ∙ resets 11:45pm"  
     "5-hour limit reached ∙ resets 12pm"
     "5-hour limit reached ∙ resets 6:15am"
+    "You've hit your limit · resets 4:20am (Europe/Warsaw)"
+    "You've hit your session limit · resets 4:20am (Europe/Warsaw)"
+    "You've hit your session limit · resets 2am (Europe/Paris)"
 )
 
 current_time=$(date +%s)

--- a/test_unified_parser.sh
+++ b/test_unified_parser.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Simple test script for the unified parse_limit_message function
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="${SCRIPT_DIR}/claude-auto-resume.sh"
@@ -14,37 +15,166 @@ source "$SCRIPT_PATH" 2>/dev/null || {
 echo "Testing unified parse_limit_message function..."
 echo "=============================================="
 
-# Test cases
-test_messages=(
-    "Claude AI usage limit reached|1735776000"
-    "5-hour limit reached ∙ resets 3am"
-    "5-hour limit reached ∙ resets 12:30am" 
-    "5-hour limit reached ∙ resets 11:45pm"
-    "5-hour limit reached ∙ resets 12pm"
-    "5-hour limit reached ∙ resets 6:15am"
-)
+tests_run=0
+tests_failed=0
 
-current_time=$(date +%s)
+pass() {
+    echo "  PASS: $1"
+}
 
-for msg in "${test_messages[@]}"; do
-    echo "Testing: $msg"
+fail() {
+    echo "  FAIL: $1"
+    tests_failed=$((tests_failed + 1))
+}
+
+assert_numeric_timestamp() {
+    local name="$1"
+    local msg="$2"
+    local timestamp
+
+    tests_run=$((tests_run + 1))
+    echo "Testing: $name"
+    if timestamp=$(parse_limit_message "$msg" 2>/dev/null) &&
+        [[ "$timestamp" =~ ^[0-9]+$ ]] &&
+        [ "$timestamp" -gt 0 ]; then
+        pass "parsed timestamp $timestamp"
+    else
+        fail "could not parse a valid timestamp from: $msg"
+    fi
+}
+
+assert_exact_timestamp() {
+    local name="$1"
+    local msg="$2"
+    local expected="$3"
+    local timestamp
+
+    tests_run=$((tests_run + 1))
+    echo "Testing: $name"
+    if timestamp=$(parse_limit_message "$msg" 2>/dev/null) && [ "$timestamp" = "$expected" ]; then
+        pass "parsed expected timestamp $expected"
+    else
+        fail "expected timestamp $expected, got '${timestamp:-<none>}'"
+    fi
+}
+
+format_time_in_tz() {
+    local timestamp="$1"
+    local timezone="$2"
+
+    if date --version >/dev/null 2>&1; then
+        TZ="$timezone" date -d "@$timestamp" "+%H:%M"
+    else
+        TZ="$timezone" date -r "$timestamp" "+%H:%M"
+    fi
+}
+
+assert_reset_time() {
+    local name="$1"
+    local msg="$2"
+    local timezone="$3"
+    local expected_time="$4"
+    local timestamp actual_time
+
+    tests_run=$((tests_run + 1))
+    echo "Testing: $name"
     if timestamp=$(parse_limit_message "$msg" 2>/dev/null); then
-        if [[ "$timestamp" =~ ^[0-9]+$ ]] && [ "$timestamp" -gt 0 ]; then
-            echo "  ✓ SUCCESS: Generated timestamp $timestamp"
-            # Format timestamp for display
-            if date --version >/dev/null 2>&1; then
-                formatted_time=$(date -d "@$timestamp" "+%Y-%m-%d %H:%M:%S")
-            else
-                formatted_time=$(date -r "$timestamp" "+%Y-%m-%d %H:%M:%S")
-            fi
-            echo "  ✓ Formatted time: $formatted_time"
+        actual_time=$(format_time_in_tz "$timestamp" "$timezone")
+        if [ "$actual_time" = "$expected_time" ]; then
+            pass "parsed reset time $actual_time in $timezone"
         else
-            echo "  ✗ FAIL: Invalid timestamp: $timestamp"
+            fail "expected reset time $expected_time in $timezone, got $actual_time"
         fi
     else
-        echo "  ✗ FAIL: Could not parse message"
+        fail "could not parse reset timestamp from: $msg"
     fi
-    echo
-done
+}
 
-echo "Test completed."
+classify_claude_result() {
+    local exit_code="$1"
+    local output="$2"
+    local limit_msg
+
+    limit_msg=$(detect_limit_message "$output" || true)
+    if [ -n "$limit_msg" ]; then
+        echo "usage_limit"
+    elif [ "$exit_code" -ne 0 ]; then
+        echo "execution_error"
+    else
+        echo "no_limit"
+    fi
+}
+
+assert_classification() {
+    local name="$1"
+    local exit_code="$2"
+    local output="$3"
+    local expected="$4"
+    local actual
+
+    tests_run=$((tests_run + 1))
+    echo "Testing: $name"
+    actual=$(classify_claude_result "$exit_code" "$output")
+    if [ "$actual" = "$expected" ]; then
+        pass "classified as $expected"
+    else
+        fail "expected $expected, got $actual"
+    fi
+}
+
+assert_exact_timestamp \
+    "old timestamp format" \
+    "Claude AI usage limit reached|1735776000" \
+    "1735776000"
+
+assert_numeric_timestamp "5-hour reset at 3am" "5-hour limit reached ∙ resets 3am"
+assert_numeric_timestamp "5-hour reset at 12:30am" "5-hour limit reached ∙ resets 12:30am"
+assert_numeric_timestamp "5-hour reset at 11:45pm" "5-hour limit reached ∙ resets 11:45pm"
+assert_numeric_timestamp "5-hour reset at 12pm" "5-hour limit reached ∙ resets 12pm"
+assert_numeric_timestamp "5-hour reset at 6:15am" "5-hour limit reached ∙ resets 6:15am"
+
+assert_reset_time \
+    "Claude latest limit format without session" \
+    "You've hit your limit · resets 4:20am (Europe/Warsaw)" \
+    "Europe/Warsaw" \
+    "04:20"
+
+assert_reset_time \
+    "Claude latest session limit with minutes" \
+    "You've hit your session limit · resets 4:20am (Europe/Warsaw)" \
+    "Europe/Warsaw" \
+    "04:20"
+
+assert_reset_time \
+    "Claude latest session limit hour-only" \
+    "You've hit your session limit · resets 2am (Europe/Paris)" \
+    "Europe/Paris" \
+    "02:00"
+
+assert_classification \
+    "session limit output with Claude exit code 1" \
+    1 \
+    "You've hit your session limit · resets 4:20am (Europe/Warsaw)" \
+    "usage_limit"
+
+assert_classification \
+    "unrelated Claude CLI failure" \
+    1 \
+    "Error: authentication failed" \
+    "execution_error"
+
+assert_classification \
+    "non-limit text mentioning limit without reset" \
+    1 \
+    "You've hit your context limit. Try a shorter prompt." \
+    "execution_error"
+
+echo
+echo "Tests run: $tests_run"
+echo "Tests failed: $tests_failed"
+
+if [ "$tests_failed" -ne 0 ]; then
+    exit 1
+fi
+
+echo "All unified parser tests passed."


### PR DESCRIPTION
## Summary

Adds support for the latest Claude Code usage-limit message format:

```text
You've hit your session limit · resets 4:20am (Europe/Warsaw)
```

Previously, the additional `session` word prevented the script from recognizing the response as a usage limit. Since Claude exits with status code `1`, the script reported a generic CLI execution error instead of waiting for the reset time.

## Changes

- support both `hit your limit` and `hit your session limit`;
- update documented supported formats;
- add regression tests for messages with and without `session`;
- preserve existing limit detection behavior.

## Reproduction

```bash
claude -p 'check'
```

Output with Claude Code 2.1.187:

```text
You've hit your session limit · resets 4:20am (Europe/Warsaw)
```

## Testing

- `make test` - passed
- `./test_unified_parser.sh` - passed, including `session` messages, reset-time extraction, exit-code-1 classification, and unrelated-error classification
- `./test_message_parsing.sh` - passed
- `./test_message_formats.sh` - passed
- `bash -n claude-auto-resume.sh test_message_formats.sh test_message_parsing.sh test_unified_parser.sh test-simulate-limit.sh` - passed
- `git diff --check` - passed

Not run locally:

- `shellcheck` - not installed in this environment
- PowerShell parser check - `pwsh` not installed in this environment